### PR TITLE
Add preliminary ESP32 porting stubs

### DIFF
--- a/include/iso15118/detail/io/helper_ssl.hpp
+++ b/include/iso15118/detail/io/helper_ssl.hpp
@@ -6,6 +6,10 @@
 
 namespace iso15118::io {
 
+#ifdef ESP_PLATFORM
+void log_and_raise_tls_error(const std::string& error_msg);
+#else
 void log_and_raise_openssl_error(const std::string& error_msg);
+#endif
 
 } // namespace iso15118::io

--- a/include/iso15118/io/tls_wrapper.hpp
+++ b/include/iso15118/io/tls_wrapper.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+#include <mbedtls/ssl.h>
+namespace iso15118::io {
+struct TlsSocket {
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    int sock;
+};
+int tls_read(TlsSocket*, void*, size_t);
+int tls_write(TlsSocket*, const void*, size_t);
+}
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,8 @@
+[env:esp32s3]
+platform = espressif32
+board = esp32s3box
+framework = espidf
+build_type = release
+monitor_speed = 115200
+lib_deps =
+

--- a/port/esp32/posix_stub.hpp
+++ b/port/esp32/posix_stub.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <lwip/sockets.h>
+#include <lwip/netdb.h>
+#include <esp_netif.h>
+#include <fcntl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+// Provide minimal POSIX compatibility wrappers
+
+struct ifaddrs {
+    struct ifaddrs* ifa_next;
+    char* ifa_name;
+    struct sockaddr* ifa_addr;
+};
+
+inline int getifaddrs(struct ifaddrs**){ return -1; }
+inline void freeifaddrs(struct ifaddrs*){}
+

--- a/port/esp32/socket_helper.cpp
+++ b/port/esp32/socket_helper.cpp
@@ -1,0 +1,30 @@
+#include "posix_stub.hpp"
+#include <iso15118/detail/io/socket_helper.hpp>
+#include <esp_netif.h>
+
+namespace iso15118::io {
+
+bool check_and_update_interface(std::string& name) {
+    if (name == "auto") {
+        name = "STA"; // default Wi-Fi interface
+    }
+    return true;
+}
+
+bool get_first_sockaddr_in6_for_interface(const std::string& if_name, sockaddr_in6& dst) {
+    esp_netif_ip_info_t info;
+    // For demo: query link local address of default interface
+    auto netif = esp_netif_get_handle_from_ifkey(if_name.c_str());
+    if (!netif) {
+        return false;
+    }
+    if (esp_netif_get_ip6_linklocal(netif, &info.ip) != ESP_OK) {
+        return false;
+    }
+    memset(&dst, 0, sizeof(dst));
+    dst.sin6_family = AF_INET6;
+    memcpy(&dst.sin6_addr, &info.ip6.addr, sizeof(dst.sin6_addr));
+    return true;
+}
+
+} // namespace iso15118::io

--- a/port/esp32/tls_wrapper.cpp
+++ b/port/esp32/tls_wrapper.cpp
@@ -1,0 +1,29 @@
+#include "posix_stub.hpp"
+#include <mbedtls/ssl.h>
+#include <mbedtls/ssl_ticket.h>
+#include <mbedtls/error.h>
+#include <cstring>
+
+namespace iso15118::io {
+struct TlsSocket {
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    int sock;
+};
+
+static void tls_socket_init(TlsSocket& t) {
+    mbedtls_ssl_init(&t.ssl);
+    mbedtls_ssl_config_init(&t.conf);
+    t.sock = -1;
+}
+
+int tls_read(TlsSocket* t, void* buf, size_t len) {
+    if (!t) return -1;
+    return mbedtls_ssl_read(&t->ssl, reinterpret_cast<unsigned char*>(buf), len);
+}
+
+int tls_write(TlsSocket* t, const void* buf, size_t len) {
+    if (!t) return -1;
+    return mbedtls_ssl_write(&t->ssl, reinterpret_cast<const unsigned char*>(buf), len);
+}
+} // namespace iso15118::io

--- a/src/iso15118/CMakeLists.txt
+++ b/src/iso15118/CMakeLists.txt
@@ -78,16 +78,22 @@ target_link_libraries(iso15118
         Threads::Threads
 )
 
-target_link_libraries(iso15118
-    PRIVATE
-        OpenSSL::SSL
-        OpenSSL::Crypto
-)
-target_sources(iso15118
-    PRIVATE
-    io/connection_ssl.cpp
-    misc/helper_ssl.cpp
-)
+if(ESP_PLATFORM)
+    target_sources(iso15118 PRIVATE
+        ../../port/esp32/socket_helper.cpp
+        ../../port/esp32/tls_wrapper.cpp
+    )
+else()
+    target_link_libraries(iso15118
+        PRIVATE
+            OpenSSL::SSL
+            OpenSSL::Crypto
+    )
+    target_sources(iso15118 PRIVATE
+        io/connection_ssl.cpp
+        misc/helper_ssl.cpp
+    )
+endif()
 
 # FIXME (aw): do we want to have this public here?
 target_compile_features(iso15118 PUBLIC cxx_std_17)

--- a/src/iso15118/io/sdp_server.cpp
+++ b/src/iso15118/io/sdp_server.cpp
@@ -7,9 +7,12 @@
 #include <endian.h>
 #include <netdb.h>
 #include <unistd.h>
-
+#ifdef ESP_PLATFORM
+#include <port/esp32/posix_stub.hpp>
+#else
 #include <arpa/inet.h>
 #include <net/if.h>
+#endif
 
 #include <cbv2g/exi_v2gtp.h>
 

--- a/src/iso15118/io/socket_helper.cpp
+++ b/src/iso15118/io/socket_helper.cpp
@@ -3,12 +3,15 @@
 #include <iso15118/detail/io/socket_helper.hpp>
 
 #include <cstring>
-
+#ifdef ESP_PLATFORM
+#include <port/esp32/posix_stub.hpp>
+#else
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#endif
 
 #include <iso15118/detail/helper.hpp>
 

--- a/src/iso15118/misc/helper_ssl.cpp
+++ b/src/iso15118/misc/helper_ssl.cpp
@@ -5,7 +5,11 @@
 #include <cassert>
 #include <stdexcept>
 
+#ifndef ESP_PLATFORM
 #include <openssl/err.h>
+#else
+#include <mbedtls/error.h>
+#endif
 
 namespace iso15118::io {
 
@@ -20,10 +24,17 @@ static void log_and_raise(const std::string& error_msg) {
     throw std::runtime_error(error_msg);
 }
 
-void log_and_raise_openssl_error(const std::string& error_msg) {
+void log_and_raise_tls_error(const std::string& error_msg) {
+#ifndef ESP_PLATFORM
     std::string error_message = {error_msg};
     ERR_print_errors_cb(&add_error_str, &error_message);
     log_and_raise(error_message);
+#else
+    char buf[128];
+    mbedtls_strerror(mbedtls_ssl_get_verify_result(nullptr), buf, sizeof(buf));
+    std::string msg = error_msg + ": " + buf;
+    log_and_raise(msg);
+#endif
 }
 
 } // namespace iso15118::io

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,4 @@
+#include <stdio.h>
+extern "C" void app_main(){
+    printf("ISO15118 port example\n");
+}


### PR DESCRIPTION
## Summary
- add ESP32 platformio configuration
- create esp32 port stubs for socket helpers and TLS
- add conditional build logic for ESP32
- stub out minimal `app_main`
- build shows failure due to missing `everest-cmake` dependency

## Testing
- `platformio run` *(fails: Could not find EVerest dependency manager)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef1a8c208324be0a1154ac5aa6c9