### PR TITLE
Add ESP-specific PollManager

### DIFF
--- a/include/iso15118/io/poll_manager.hpp
+++ b/include/iso15118/io/poll_manager.hpp
@@ -6,14 +6,23 @@
 #include <map>
 #include <vector>
 
+#ifndef ESP_PLATFORM
 #include <poll.h>
+#else
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <sys/select.h>
+#endif
 namespace iso15118::io {
 
 using PollCallback = const std::function<void()>;
+
+#ifndef ESP_PLATFORM
 struct PollSet {
     std::vector<struct pollfd> fds;
     std::vector<PollCallback*> callbacks;
 };
+#endif
 
 class PollManager {
 public:
@@ -28,9 +37,14 @@ public:
 private:
     std::map<int, PollCallback> registered_fds;
 
+    
+#ifndef ESP_PLATFORM
     PollSet poll_set;
-
     int event_fd{-1};
+#else
+    EventGroupHandle_t event_group{nullptr};
+    static constexpr EventBits_t ABORT_BIT = BIT0;
+#endif
 };
 
 } // namespace iso15118::io

--- a/library.json
+++ b/library.json
@@ -20,7 +20,8 @@
   "build": {
     "srcFilter": [
       "+<*>",
-      "-<examples>"
+      "-<examples>",
+      "-<src/iso15118/io/poll_manager.cpp>"
     ]
   }
 }

--- a/port/esp32/poll_manager.cpp
+++ b/port/esp32/poll_manager.cpp
@@ -1,0 +1,76 @@
+#include "posix_stub.hpp"
+#include <iso15118/io/poll_manager.hpp>
+#include <algorithm>
+#include <iso15118/detail/helper.hpp>
+
+namespace iso15118::io {
+
+PollManager::PollManager() {
+    event_group = xEventGroupCreate();
+}
+
+void PollManager::register_fd(int fd, PollCallback& poll_callback) {
+    registered_fds.emplace(fd, poll_callback);
+}
+
+void PollManager::unregister_fd(int fd) {
+    registered_fds.erase(fd);
+}
+
+void PollManager::poll(int timeout_ms) {
+    const int chunk_ms = 100;
+    int elapsed = 0;
+    while (true) {
+        if (xEventGroupGetBits(event_group) & ABORT_BIT) {
+            xEventGroupClearBits(event_group, ABORT_BIT);
+            return;
+        }
+
+        fd_set readfds;
+        FD_ZERO(&readfds);
+        int max_fd = -1;
+        for (auto const& [fd, cb] : registered_fds) {
+            FD_SET(fd, &readfds);
+            if (fd > max_fd) {
+                max_fd = fd;
+            }
+        }
+
+        struct timeval tv;
+        int wait_ms;
+        if (timeout_ms < 0) {
+            wait_ms = chunk_ms;
+        } else {
+            wait_ms = std::min(chunk_ms, timeout_ms - elapsed);
+            if (wait_ms < 0) {
+                return; // timeout reached
+            }
+        }
+        tv.tv_sec = wait_ms / 1000;
+        tv.tv_usec = (wait_ms % 1000) * 1000;
+
+        int ret = select(max_fd + 1, &readfds, nullptr, nullptr, &tv);
+        if (ret < 0) {
+            log_and_throw("Select failed");
+        } else if (ret > 0) {
+            for (auto const& [fd, cb] : registered_fds) {
+                if (FD_ISSET(fd, &readfds)) {
+                    cb();
+                }
+            }
+        }
+
+        if (timeout_ms >= 0) {
+            elapsed += wait_ms;
+            if (elapsed >= timeout_ms) {
+                break;
+            }
+        }
+    }
+}
+
+void PollManager::abort() {
+    xEventGroupSetBits(event_group, ABORT_BIT);
+}
+
+} // namespace iso15118::io

--- a/src/iso15118/CMakeLists.txt
+++ b/src/iso15118/CMakeLists.txt
@@ -14,7 +14,6 @@ target_sources(iso15118
 
         io/connection_plain.cpp
         io/logging.cpp
-        io/poll_manager.cpp
         io/sdp_packet.cpp
         io/sdp_server.cpp
         io/socket_helper.cpp
@@ -80,6 +79,7 @@ target_link_libraries(iso15118
 
 if(ESP_PLATFORM)
     target_sources(iso15118 PRIVATE
+        ../../port/esp32/poll_manager.cpp
         ../../port/esp32/socket_helper.cpp
         ../../port/esp32/tls_wrapper.cpp
     )
@@ -90,6 +90,7 @@ else()
             OpenSSL::Crypto
     )
     target_sources(iso15118 PRIVATE
+        io/poll_manager.cpp
         io/connection_ssl.cpp
         misc/helper_ssl.cpp
     )

--- a/src/iso15118/io/poll_manager.cpp
+++ b/src/iso15118/io/poll_manager.cpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <vector>
 
+#ifndef ESP_PLATFORM
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
@@ -85,3 +86,5 @@ void PollManager::abort() {
 }
 
 } // namespace iso15118::io
+
+#endif // !ESP_PLATFORM


### PR DESCRIPTION
## Summary
- implement a PollManager variant for ESP32 using FreeRTOS event groups and `select`
- compile the ESP version when `ESP_PLATFORM` is set
- exclude the POSIX poll manager from PlatformIO builds

## Testing
- `cmake -S . -B build -G Ninja` *(fails: could not find EVerest dependency manager)*

------
https://chatgpt.com/codex/tasks/task_e_6881032401a083249c255937429f94f2