### PR TITLE
Handle PlatformIO without EDM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,29 @@ if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TEST
 endif()
 
 # dependencies
+if(PLATFORMIO OR PioPlatform)
+    message(STATUS "PlatformIO detected - disabling EDM")
+    set(DISABLE_EDM ON)
+endif()
+
 if (NOT DISABLE_EDM)
     evc_setup_edm()
     # In EDM mode, we can't install exports (because the dependencies usually do not install their exports)
     set(ISO15118_INSTALL OFF)
 else()
-    find_package(cbv2g REQUIRED)
+    find_package(cbv2g QUIET)
+    if(NOT cbv2g_FOUND)
+        message(STATUS "Fetching libcbv2g because EDM is disabled")
+        include(FetchContent)
+        FetchContent_Declare(
+            libcbv2g
+            GIT_REPOSITORY https://github.com/EVerest/libcbv2g.git
+            GIT_TAG v0.3.1
+        )
+        FetchContent_MakeAvailable(libcbv2g)
+        # Externally fetched dependencies do not provide install rules
+        set(ISO15118_INSTALL OFF)
+    endif()
 endif()
 
 add_subdirectory(input)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ pio run -e esp32s3
 ```
 This will compile the library and the example located in `examples/esp32_demo`.
 
+When libiso15118 is built inside PlatformIO the CMake variable `PLATFORMIO` (or
+`PioPlatform`) is defined.  If EDM is not available, the build system will skip
+`evc_setup_edm()` and fetch `libcbv2g` automatically.  In rare cases you might
+need to add `-DPLATFORMIO=ON` to the CMake invocation to enable this logic.
+
 
 Acknowledgment
 --------------


### PR DESCRIPTION
## Summary
- detect PlatformIO builds and disable EDM
- fetch libcbv2g when EDM isn't available
- document PlatformIO workaround

## Testing
- `cmake -S . -B build -G Ninja -DDISABLE_EDM=ON` *(fails: lwip/sockets.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882c56cfb248324ac951cc859ad5422