### PR TITLE
Implement esp32 getifaddrs

### DIFF
--- a/port/esp32/posix_stub.hpp
+++ b/port/esp32/posix_stub.hpp
@@ -2,6 +2,8 @@
 #include <lwip/sockets.h>
 #include <lwip/netdb.h>
 #include <esp_netif.h>
+#include <cstring>
+#include <cstdlib>
 #include <fcntl.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -14,6 +16,76 @@ struct ifaddrs {
     struct sockaddr* ifa_addr;
 };
 
-inline int getifaddrs(struct ifaddrs**){ return -1; }
-inline void freeifaddrs(struct ifaddrs*){}
+inline unsigned if_nametoindex(const char* ifname) {
+    auto netif = esp_netif_get_handle_from_ifkey(ifname);
+    if (!netif) {
+        return 0;
+    }
+    return esp_netif_get_netif_impl_index(netif);
+}
+
+inline int getifaddrs(struct ifaddrs** ifap) {
+    if (!ifap) {
+        return -1;
+    }
+
+    struct ifaddrs* head = nullptr;
+    struct ifaddrs** next = &head;
+    esp_netif_t* netif = nullptr;
+
+    while ((netif = esp_netif_next(netif)) != nullptr) {
+        auto entry = static_cast<ifaddrs*>(std::calloc(1, sizeof(ifaddrs)));
+        if (!entry) {
+            freeifaddrs(head);
+            return -1;
+        }
+
+        const char* key = esp_netif_get_ifkey(netif);
+        if (key) {
+            entry->ifa_name = strdup(key);
+        }
+
+        esp_ip6_addr_t ip6{};
+        if (esp_netif_get_ip6_linklocal(netif, &ip6) == ESP_OK) {
+            auto addr6 = static_cast<sockaddr_in6*>(std::calloc(1, sizeof(sockaddr_in6)));
+            if (!addr6) {
+                free(entry);
+                freeifaddrs(head);
+                return -1;
+            }
+            addr6->sin6_family = AF_INET6;
+            std::memcpy(&addr6->sin6_addr, &ip6, sizeof(ip6));
+            entry->ifa_addr = reinterpret_cast<sockaddr*>(addr6);
+        } else {
+            esp_netif_ip_info_t ip{};
+            if (esp_netif_get_ip_info(netif, &ip) == ESP_OK) {
+                auto addr4 = static_cast<sockaddr_in*>(std::calloc(1, sizeof(sockaddr_in)));
+                if (!addr4) {
+                    free(entry);
+                    freeifaddrs(head);
+                    return -1;
+                }
+                addr4->sin_family = AF_INET;
+                addr4->sin_addr.s_addr = ip.ip.addr;
+                entry->ifa_addr = reinterpret_cast<sockaddr*>(addr4);
+            }
+        }
+
+        *next = entry;
+        next = &entry->ifa_next;
+    }
+
+    *ifap = head;
+    return 0;
+}
+
+inline void freeifaddrs(struct ifaddrs* ifa) {
+    while (ifa) {
+        auto next = ifa->ifa_next;
+        std::free(ifa->ifa_name);
+        std::free(ifa->ifa_addr);
+        std::free(ifa);
+        ifa = next;
+    }
+}
 

--- a/port/esp32/socket_helper.cpp
+++ b/port/esp32/socket_helper.cpp
@@ -1,30 +1,96 @@
 #include "posix_stub.hpp"
 #include <iso15118/detail/io/socket_helper.hpp>
-#include <esp_netif.h>
+#include <cstring>
+#include <netinet/in.h>
 
 namespace iso15118::io {
 
-bool check_and_update_interface(std::string& name) {
-    if (name == "auto") {
-        name = "STA"; // default Wi-Fi interface
+namespace {
+
+auto choose_first_ipv6_interface() {
+    std::string interface_name{};
+    struct ifaddrs* if_list_head;
+    const auto get_if_addrs_result = getifaddrs(&if_list_head);
+
+    if (get_if_addrs_result == -1) {
+        logf_error("Failed to call getifaddrs");
+        return std::string("");
     }
-    return true;
+
+    for (auto current_if = if_list_head; current_if != nullptr; current_if = current_if->ifa_next) {
+        if (current_if->ifa_addr == nullptr || current_if->ifa_addr->sa_family != AF_INET6) {
+            continue;
+        }
+
+        const auto current_addr = reinterpret_cast<const sockaddr_in6*>(current_if->ifa_addr);
+        if (!IN6_IS_ADDR_LINKLOCAL(&(current_addr->sin6_addr))) {
+            continue;
+        }
+        interface_name = current_if->ifa_name;
+        break;
+    }
+    freeifaddrs(if_list_head);
+    return interface_name;
 }
 
-bool get_first_sockaddr_in6_for_interface(const std::string& if_name, sockaddr_in6& dst) {
-    esp_netif_ip_info_t info;
-    // For demo: query link local address of default interface
-    auto netif = esp_netif_get_handle_from_ifkey(if_name.c_str());
-    if (!netif) {
+} // namespace
+
+bool check_and_update_interface(std::string& interface_name) {
+    if (interface_name == "auto") {
+        logf_info("Search for the first available ipv6 interface");
+        interface_name = choose_first_ipv6_interface();
+    }
+
+    struct ipv6_mreq mreq {};
+    mreq.ipv6mr_interface = if_nametoindex(interface_name.c_str());
+    if (!mreq.ipv6mr_interface) {
+        logf_error("No such interface: %s", interface_name.c_str());
         return false;
     }
-    if (esp_netif_get_ip6_linklocal(netif, &info.ip) != ESP_OK) {
-        return false;
+    return !interface_name.empty();
+}
+
+bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, sockaddr_in6& address) {
+    struct ifaddrs* if_list_head;
+    const auto get_if_addrs_result = getifaddrs(&if_list_head);
+
+    if (get_if_addrs_result == -1) {
+        log_and_throw("Failed to call getifaddrs");
     }
-    memset(&dst, 0, sizeof(dst));
-    dst.sin6_family = AF_INET6;
-    memcpy(&dst.sin6_addr, &info.ip6.addr, sizeof(dst.sin6_addr));
-    return true;
+
+    bool found_interface = false;
+
+    for (auto current_if = if_list_head; current_if != nullptr; current_if = current_if->ifa_next) {
+        if (current_if->ifa_addr == nullptr) {
+            continue;
+        }
+
+        if (current_if->ifa_addr->sa_family != AF_INET6) {
+            continue;
+        }
+
+        if (interface_name.compare("auto") != 0 && interface_name.compare(current_if->ifa_name) != 0) {
+            continue;
+        }
+
+        const auto current_addr = reinterpret_cast<const sockaddr_in6*>(current_if->ifa_addr);
+
+        if (interface_name.compare("lo") != 0 && !IN6_IS_ADDR_LINKLOCAL(&(current_addr->sin6_addr))) {
+            continue;
+        }
+
+        if (interface_name == "auto") {
+            logf_info("Found an ipv6 link local address for interface: %s", current_if->ifa_name);
+        }
+
+        std::memcpy(&address, current_addr, sizeof(address));
+        found_interface = true;
+        break;
+    }
+
+    freeifaddrs(if_list_head);
+
+    return found_interface;
 }
 
 } // namespace iso15118::io


### PR DESCRIPTION
## Summary
- implement `getifaddrs` and `freeifaddrs` using ESP-IDF APIs
- provide `if_nametoindex` helper
- update ESP32 socket helper to auto-detect interfaces via the new implementation

## Testing
- `cmake .. -DDISABLE_EDM=ON -DBUILD_TESTING=OFF`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_688348c70ca88324a7bb6c04fc2a0d7f