### PR TITLE
Document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Dependencies
 
 To build this library you need [everest-cmake](https://github.com/EVerest/everest-cmake) checkout in the same directory as libiso15118. If no `everest-cmake` is available, it is retrieved via FetchContent.
 
+See [THIRD_PARTY.md](THIRD_PARTY.md) for a list of external libraries and their licenses.
+
 For Debian GNU/Linux 12 you will need the following dependencies:
 
 ```bash

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,1 +1,18 @@
-_Use this file to list out any third-party dependencies used by this project. You may choose to point to a Gemfile or other language specific packaging file for details._
+# Third-Party Libraries
+
+This project relies on several external libraries. The table below lists the
+main libraries used during build and runtime together with their license and
+source location.
+
+| Library | License | Source |
+| ------- | ------- | ------ |
+| **libcbv2g** | Apache-2.0 | <https://github.com/EVerest/libcbv2g> |
+| **libslac** (optional) | Apache-2.0 | <https://github.com/EVerest/libslac> |
+| **OpenSSL** | Apache-2.0 | <https://www.openssl.org> |
+| **mbedTLS** | Apache-2.0 | <https://github.com/Mbed-TLS/mbedtls> |
+| **Catch2** | BSL-1.0 | <https://github.com/catchorg/Catch2> |
+
+`libcbv2g` provides the EXI message handling used by libiso15118.  `libslac`
+may be used for SLAC message definitions.  TLS support can be implemented using
+either OpenSSL (typical on desktop systems) or mbedTLS (used on embedded
+platforms).  Unit tests are implemented with the Catch2 framework.


### PR DESCRIPTION
## Summary
- document usage of bundled dependencies and their licenses
- link the README dependencies section to `THIRD_PARTY.md`

## Testing
- `cmake -S . -B build -G Ninja -DBUILD_TESTING=OFF -DDISABLE_EDM=ON`
- `ninja -C build`

------
https://chatgpt.com/codex/tasks/task_e_688348eb0f9c8324b9c6cf972b149bfd