### PR TITLE
Replace filesystem path with string

### DIFF
--- a/include/iso15118/config.hpp
+++ b/include/iso15118/config.hpp
@@ -2,9 +2,11 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include <filesystem>
 #include <optional>
 #include <string>
+#ifndef ESP_PLATFORM
+#include <filesystem>
+#endif
 
 namespace iso15118::config {
 
@@ -32,7 +34,7 @@ struct SSLConfig {
     bool enable_ssl_logging{false};
     bool enable_tls_key_logging{false};
     bool enforce_tls_1_3{false};
-    std::filesystem::path tls_key_logging_path{};
+    std::string tls_key_logging_path{};
 };
 
 } // namespace iso15118::config

--- a/src/iso15118/io/connection_ssl.cpp
+++ b/src/iso15118/io/connection_ssl.cpp
@@ -7,7 +7,9 @@
 #include <cassert>
 #include <cinttypes>
 #include <cstring>
+#ifndef ESP_PLATFORM
 #include <filesystem>
+#endif
 #include <fstream>
 #include <sstream>
 #include <unistd.h>
@@ -21,9 +23,9 @@
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #else
+#include <mbedtls/error.h>
 #include <mbedtls/ssl.h>
 #include <mbedtls/ssl_ticket.h>
-#include <mbedtls/error.h>
 #endif
 
 #include <iso15118/detail/helper.hpp>
@@ -319,7 +321,7 @@ ConnectionSSL::ConnectionSSL(PollManager& poll_manager_, const std::string& inte
     ssl->ssl_ctx = std::unique_ptr<SSL_CTX>(ssl_ctx);
 
     if (ssl_keylog_file_index != -1) {
-        ssl->tls_key_log_file_path = ssl_config.tls_key_logging_path / "tls_session_keys.log";
+        ssl->tls_key_log_file_path = std::filesystem::path(ssl_config.tls_key_logging_path) / "tls_session_keys.log";
         SSL_CTX_set_ex_data(ssl->ssl_ctx.get(), ssl_keylog_file_index, &ssl->tls_key_log_file_path);
     }
     sockaddr_in6 address;

--- a/test/iso15118/io/connection_openssl.cpp
+++ b/test/iso15118/io/connection_openssl.cpp
@@ -1,4 +1,6 @@
+#ifndef ESP_PLATFORM
 #include <filesystem>
+#endif
 #include <iostream>
 #include <string>
 #include <unistd.h>
@@ -16,7 +18,7 @@ static constexpr auto POLL_MANAGER_TIMEOUT_MS = 50;
 static constexpr auto STOP_TIME = 30;
 
 const char* short_opts = "hi:";
-std::string interface {};
+std::string interface{};
 
 void parse_options(int argc, char** argv) {
     int c{0};


### PR DESCRIPTION
## Summary
- make `tls_key_logging_path` a `std::string`
- convert it to a `std::filesystem::path` internally
- guard `<filesystem>` includes for embedded builds

## Testing
- `cmake -S . -B build -G Ninja -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `ninja -C build`

------
https://chatgpt.com/codex/tasks/task_e_68839be6bf4883249264048d180e0763