### PR TITLE
Restore esp32s3 PlatformIO env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,3 +5,11 @@ src_dir = examples/esp32_demo
 [env:native]
 platform = native
 build_flags = -DPLATFORMIO=ON
+
+[env:esp32s3]
+platform = espressif32
+board = esp32s3box
+framework = espidf
+lib_extra_dirs = .
+monitor_speed = 115200
+lib_ldf_mode = deep


### PR DESCRIPTION
## Summary
- restore the `esp32s3` PlatformIO environment so that README instructions work

## Testing
- `pio run -e native`
- `pio run -e esp32s3` *(fails: aborted after lengthy toolchain download)*

------
https://chatgpt.com/codex/tasks/task_e_68839bea51408324aaae9f768593c776